### PR TITLE
make 'Task.result' raise InvalidStateError instead of CancelledError …

### DIFF
--- a/asyncgui/_core.py
+++ b/asyncgui/_core.py
@@ -14,7 +14,7 @@ from inspect import (
 import enum
 from contextlib import asynccontextmanager
 
-from asyncgui.exceptions import CancelledError, InvalidStateError
+from asyncgui.exceptions import InvalidStateError
 
 
 class TaskState(enum.Flag):
@@ -106,7 +106,7 @@ class Task:
         if state is TaskState.DONE:
             return self._result
         elif state is TaskState.CANCELLED:
-            raise CancelledError(f"{self} was cancelled")
+            raise InvalidStateError(f"{self} was cancelled")
         else:
             raise InvalidStateError(f"Result of {self} is not ready")
 

--- a/tests/test_core_task.py
+++ b/tests/test_core_task.py
@@ -63,7 +63,7 @@ def test_the_state_and_the_result__ver_cancel():
     assert task.state is TS.CANCELLED
     assert not task.done
     assert task.cancelled
-    with pytest.raises(ag.CancelledError):
+    with pytest.raises(ag.InvalidStateError):
         task.result
 
 
@@ -96,7 +96,7 @@ def test_the_state_and_the_result__ver_uncaught_exception():
     job_state = 'C'
     assert not task.done
     assert task.cancelled
-    with pytest.raises(ag.CancelledError):
+    with pytest.raises(ag.InvalidStateError):
         task.result
 
 
@@ -128,7 +128,7 @@ def test_the_state_and_the_result__ver_uncaught_exception2():
     job_state = 'B'
     assert not task.done
     assert task.cancelled
-    with pytest.raises(ag.CancelledError):
+    with pytest.raises(ag.InvalidStateError):
         task.result
 
 


### PR DESCRIPTION
…when Task.state is CANCELLED