### PR TITLE
allows the user to deal with Task cancellation flexibly

### DIFF
--- a/asyncgui/exceptions.py
+++ b/asyncgui/exceptions.py
@@ -1,7 +1,4 @@
-'''Took from asyncio'''
-
-
-__all__ = ('CancelledError', 'InvalidStateError', )
+__all__ = ('CancelledError', 'InvalidStateError', 'CancelRequest', )
 
 
 class CancelledError(BaseException):
@@ -10,3 +7,9 @@ class CancelledError(BaseException):
 
 class InvalidStateError(Exception):
     """The operation is not allowed in the current state."""
+
+
+class CancelRequest(BaseException):
+    """(internal) Not an actual exception. Used for flow control.
+    We should not catch this exception.
+    """


### PR DESCRIPTION
Since coroutines cannot be closed if `getcoroutinestate(coro) == CORO_RUNNING`, `Task.cancel()` may or may not fail depending on the internal coroutine's state. This PR gives the user a workaround.

## workaround A (recommended)

If a Task is not cancellable, schedule `Task.cancel()` to be called later

```python
if task.is_cancellable:
    task.cancel()
else:
    your_gui_librarys_scheduling_feature(lambda *args, **kwargs: task.cancel())
```

## workaround B

Even if a Task is not cancellable, cancel it by using `asyncgui.CancelRequest`

```python
if task.is_cancellable:
    task.cancel()
else:
    raise asyncgui.CancelRequest
```
