### PR TITLE
複数のtaskを捌く系のAPIを変更

### DIFF
--- a/asyncgui/_core.py
+++ b/asyncgui/_core.py
@@ -1,7 +1,7 @@
 __all__ = (
-    'start', 'sleep_forever', 'or_', 'and_', 'Event', 'Task', 'TaskState',
+    'start', 'sleep_forever', 'Event', 'Task', 'TaskState',
     'get_current_task', 'get_step_coro', 'aclosing', 'Awaitable_or_Task',
-    'and_from_iterable', 'or_from_iterable',
+    'unstructured_or', 'unstructured_and',
 )
 
 import itertools
@@ -225,10 +225,10 @@ def sleep_forever():
 
 @types.coroutine
 def _gather(aws_and_tasks: typing.Iterable[Awaitable_or_Task], *, n: int=None) \
-        -> typing.Sequence[Task]:
+        -> typing.List[Task]:
     '''(internal)'''
-    tasks = tuple(
-        v if isinstance(v, Task) else Task(v) for v in aws_and_tasks)
+    tasks = [
+        v if isinstance(v, Task) else Task(v) for v in aws_and_tasks]
     n_left = n if n is not None else len(tasks)
 
     def step_coro():
@@ -255,19 +255,11 @@ def _gather(aws_and_tasks: typing.Iterable[Awaitable_or_Task], *, n: int=None) \
     return tasks
 
 
-async def or_(*aws_and_tasks):
+async def unstructured_or(*aws_and_tasks):
     return await _gather(aws_and_tasks, n=1)
 
 
-async def or_from_iterable(aws_and_tasks):
-    return await _gather(aws_and_tasks, n=1)
-
-
-async def and_(*aws_and_tasks):
-    return await _gather(aws_and_tasks)
-
-
-async def and_from_iterable(aws_and_tasks):
+async def unstructured_and(*aws_and_tasks):
     return await _gather(aws_and_tasks)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,8 +63,8 @@ class Test_or_:
         import asyncgui as ag
         events = [ag.Event() for __ in range(3)]
         async def _test():
-            tasks = await ag.or_from_iterable(
-                event.wait() for event in events)
+            tasks = await ag.unstructured_or(*(
+                event.wait() for event in events))
             assert not tasks[0].done
             assert tasks[1].done
             assert not tasks[2].done
@@ -82,7 +82,7 @@ class Test_or_:
         async def do_nothing():
             pass
         async def _test():
-            tasks = await ag.or_(
+            tasks = await ag.unstructured_or(
                 *(do_nothing() for __ in range(n_do_nothing)),
                 *(ag.Event().wait() for __ in range(3 - n_do_nothing)),
             )
@@ -101,8 +101,8 @@ class Test_and_:
         import asyncgui as ag
         events = [ag.Event() for __ in range(3)]
         async def _test():
-            tasks = await ag.and_from_iterable(
-                event.wait() for event in events)
+            tasks = await ag.unstructured_and(*(
+                event.wait() for event in events))
             assert tasks[0].done
             assert tasks[1].done
             assert tasks[2].done
@@ -124,8 +124,8 @@ class Test_and_:
         async def do_nothing():
             pass
         async def _test():
-            tasks = await ag.and_from_iterable(
-                do_nothing() for __ in range(n_coros))
+            tasks = await ag.unstructured_and(*(
+                do_nothing() for __ in range(n_coros)))
             for task in tasks:
                 assert task.done
             nonlocal done; done = True


### PR DESCRIPTION
### What the PR does

- remove `or_from_iterable()` and  `and_from_iterable()`
- rename `or_()` -> `unstructured_or()`
- rename `and_()` -> `unstructured_and()`