### PR TITLE
remove NoChildLeft

### DIFF
--- a/asyncgui/exceptions.py
+++ b/asyncgui/exceptions.py
@@ -15,7 +15,7 @@ class EndOfConcurrency(BaseException):
 
 
 class NoChildLeft(Exception):
-    """There is no child to wait for"""
+    """(no longer used)"""
 
 
 class WouldBlock(Exception):

--- a/tests/structured_concurrency/or/test_simple_situation.py
+++ b/tests/structured_concurrency/or/test_simple_situation.py
@@ -186,8 +186,9 @@ def test_cancel_all_children():
     TS = ag.TaskState
 
     async def main():
-        with pytest.raises(ag.NoChildLeft):
-            await or_(child1, child2)
+        tasks = await or_(child1, child2)
+        for task in tasks:
+            assert task.cancelled
 
     child1 = ag.Task(ag.sleep_forever())
     child2 = ag.Task(ag.sleep_forever())


### PR DESCRIPTION
If the process is closed while there is a task waiting for `await or(...)` to return, `NoChildLeft` error will occur even though the code itself is not wrong. Which is annoyting because in order to avoid that, you *always* have to surround `or(...)` with `try except`:

```python
import asyncgui
from asyncgui.structured_concurrency import or_

async def async_func():
    try:
        await or(...)  # If  the process is closed at here, NoChildLeft will occur
    except asyncgui.NoChildLeft:
        pass
```

So I decided to remove `NoChildLeft`.