### PR TITLE
rename 'get_current_task()' -> 'current_task()'

### DIFF
--- a/tests/structured_concurrency/wait_all/test_complicated_situation_1.py
+++ b/tests/structured_concurrency/wait_all/test_complicated_situation_1.py
@@ -21,7 +21,7 @@ async def child_a(ctx):
     elif what == 'fail':
         raise ZeroDivisionError
     elif what == 'cancel_self':
-        task_a = await ag.get_current_task()
+        task_a = await ag.current_task()
         task_a.cancel()
         await ag.sleep_forever()
     else:

--- a/tests/structured_concurrency/wait_all/test_complicated_situation_2.py
+++ b/tests/structured_concurrency/wait_all/test_complicated_situation_2.py
@@ -20,7 +20,7 @@ async def child_a(ctx):
     elif what == 'fail':
         raise ZeroDivisionError
     elif what == 'cancel_self':
-        task_a = await ag.get_current_task()
+        task_a = await ag.current_task()
         task_a.cancel()
         await ag.sleep_forever()
     else:

--- a/tests/structured_concurrency/wait_any/test_complicated_situation_1.py
+++ b/tests/structured_concurrency/wait_any/test_complicated_situation_1.py
@@ -21,7 +21,7 @@ async def child_a(ctx):
     elif what == 'fail':
         raise ZeroDivisionError
     elif what == 'cancel_self':
-        task_a = await ag.get_current_task()
+        task_a = await ag.current_task()
         task_a.cancel()
         await ag.sleep_forever()
     else:

--- a/tests/structured_concurrency/wait_any/test_complicated_situation_2.py
+++ b/tests/structured_concurrency/wait_any/test_complicated_situation_2.py
@@ -20,7 +20,7 @@ async def child_a(ctx):
     elif what == 'fail':
         raise ZeroDivisionError
     elif what == 'cancel_self':
-        task_a = await ag.get_current_task()
+        task_a = await ag.current_task()
         task_a.cancel()
         await ag.sleep_forever()
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ def test_get_current_task():
     done = False
 
     async def async_fn():
-        task = await ag.get_current_task()
+        task = await ag.current_task()
         assert isinstance(task, ag.Task)
         nonlocal done;done = True
 
@@ -133,7 +133,7 @@ def test_disable_cancellation__ver_self():
     import asyncgui as ag
 
     async def async_fn():
-        task = await ag.get_current_task()
+        task = await ag.current_task()
         async with ag.disable_cancellation():
             task.cancel()
             await ag.sleep_forever()


### PR DESCRIPTION
Because both `asyncio` and `trio` use this name.