### PR TITLE
add 'open_cancel_scope()'

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -53,3 +53,16 @@ def async_func():
 結果的に内側の `Task._step()` が `StopIteration` を受け取った場合は外側の　`Task._step()` では例外が起こらないのにcoroの状態が `CORO_CLOSED` に変わっている。
 この事は `Task._throw_exc()` と `asyncgui.start()` にも言える。
 なので `Task._actual_cancel()` を呼ぶ前にはcoroの状態が `CORO_SUSPENDED` であるかの確認が必要と思う。
+
+# 中断scopeが連続した場合の懸念
+
+```python
+async def async_fn():
+    with open_cancel_scope() as scope1:
+        scope1.cancel()
+    with open_cancel_scope() as scope2:
+        await ...
+```
+
+scope1とscope2は深さが同じであるため`scope1.cancel()`はscope2を中断させてしまう。
+これを防ぐためにはcontextmanager側が中断を取り消す必要がありそう。

--- a/Notes.md
+++ b/Notes.md
@@ -46,6 +46,22 @@ def async_func():
 ただこのやり方だと利用者が片方の例外を書き忘れる怖れがあって危険だと思う。
 ではcoroへの参照(実際にはcoroを包んでいるTaskへの参照)を何らかの方法で保持してGCに捨てられないようにしたらどうかという話になりますが、良い方法を思いつかないので独自例外は用いない方向でいく事にする。
 
+### 追記(2023/05/22)
+
+両方の例外を含んだtupleを用意してやれば利用者側が書き忘れる可能性は低いだろう。
+
+```python
+
+Cancelled = (GeneratorExit, 独自例外, )
+
+def async_func():
+    try:
+        ...
+    except Cancelled:
+        中断時に行いたい処理
+        raise
+```
+
 # coro.send()で例外が起きなかった場合でも状態がCORO_CLOSEDになる事がある
 
 `investigation/current_task_enlarges_the_call_stack.py` を実行して分かる通り `current_task()` だけを `await` しているとcall stackは肥っていく。

--- a/investigation/GeneratorExit_instance_is_replaced_with_another_one.py
+++ b/investigation/GeneratorExit_instance_is_replaced_with_another_one.py
@@ -1,0 +1,44 @@
+'''
+A行に代えてB行を用いるとユニットテストが通らなくなる事から分かる通り文字列'Hello'が渡らなくなってしまうようである。
+またオブジェクトの id() が異なる事からGeneratorExitのインスタンスのすり替えが起こっているようである。
+'''
+
+import types
+import pytest
+
+
+@types.coroutine
+def sleep_forever():
+    yield lambda: None
+
+
+async def async_fn():
+    try:
+        await sleep_forever()
+    except BaseException as e:
+        print(id(e), 'caught')
+        if e.args and (e.args[0] == 'Hello'):
+            return
+    pytest.fail()
+
+
+async def wrapper():
+    return await async_fn()
+
+
+@pytest.mark.parametrize('exc_cls', (Exception, BaseException, GeneratorExit))
+def test_exc(exc_cls):
+    print("\n", exc_cls)
+    coro = async_fn()  # A
+    # coro = wrapper()  # B
+    coro.send(None)
+    e = exc_cls('Hello')
+    print(id(e), 'about to be thrown')
+    try:
+        coro.throw(e)
+    except StopIteration:
+        pass
+
+
+if __name__ == '__main__':
+    pytest.main(['-s', __file__])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,7 @@ flake8 = "^4.0.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+xfail_strict = true
+addopts = "--maxfail=4 --strict-markers"

--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -170,7 +170,7 @@ class Task:
         except StopIteration:
             pass
         else:
-            if self._cancel_called and (not self._disable_cancellation):
+            if self._cancel_called and self._is_cancellable:
                 self._actual_cancel()
 
     def _throw_exc(self, exc):
@@ -182,7 +182,7 @@ class Task:
         except StopIteration:
             pass
         else:
-            if self._cancel_called and (not self._disable_cancellation):
+            if self._cancel_called and self._is_cancellable:
                 self._actual_cancel()
 
 
@@ -209,7 +209,7 @@ def start(aw: Aw_or_Task) -> Task:
     except StopIteration:
         pass
     else:
-        if task._cancel_called and (not task._disable_cancellation):
+        if task._cancel_called and task._is_cancellable:
             task._actual_cancel()
 
     return task

--- a/tests/structured_concurrency/wait_all/test_simple_situation.py
+++ b/tests/structured_concurrency/wait_all/test_simple_situation.py
@@ -180,15 +180,14 @@ def test_必ず例外を起こす子_を複数持つ親を中断():
     import asyncgui as ag
     TS = ag.TaskState
 
-    async def main(e):
+    async def main():
         with pytest.raises(ag.ExceptionGroup) as excinfo:
             await ag.wait_all(fail_on_cancel(), fail_on_cancel())
         assert [ZeroDivisionError, ZeroDivisionError] == [type(e) for e in excinfo.value.exceptions]
-        await e.wait()
+        await ag.sleep_forever()
         pytest.fail("Failed to cancel")
 
-    e = ag.Event()
-    main_task = ag.Task(main(e))
+    main_task = ag.Task(main())
     ag.start(main_task)
     assert main_task.state is TS.STARTED
     main_task.cancel()

--- a/tests/structured_concurrency/wait_all/test_simple_situation.py
+++ b/tests/structured_concurrency/wait_all/test_simple_situation.py
@@ -138,7 +138,7 @@ def test_one_child_fails_soon():
 
 def test_multiple_children_fail_soon():
     '''
-    MultiErrorが起こるように思えるが、１つ目の子で例外が起こるや否や２つ目
+    ２つ例外が起こるように思えるが、１つ目の子で例外が起こるや否や２つ目
     は即中断されるため、２つ目では例外は起こらない
     '''
     import asyncgui as ag
@@ -160,7 +160,7 @@ def test_multiple_children_fail_soon():
 def test_multiple_children_fail():
     '''
     １つ目の子で例外が起こる事で２つ目が中断される。その時２つ目でも例外が
-    起きるためMultiErrorが湧く。
+    起きるため２つの例外が湧く。
     '''
     import asyncgui as ag
 

--- a/tests/structured_concurrency/wait_any/test_simple_situation.py
+++ b/tests/structured_concurrency/wait_any/test_simple_situation.py
@@ -139,7 +139,7 @@ def test_one_child_fails_soon():
 
 def test_multiple_children_fail_soon():
     '''
-    MultiErrorが起こるように思えるが、１つ目の子で例外が起こるや否や２つ目
+    ２つの例外が起こるように思えるが、１つ目の子で例外が起こるや否や２つ目
     は即中断されるため、２つ目では例外は起こらない
     '''
     import asyncgui as ag
@@ -161,7 +161,7 @@ def test_multiple_children_fail_soon():
 def test_multiple_children_fail():
     '''
     １つ目の子で例外が起こる事で２つ目が中断される。その時２つ目でも例外が
-    起きるためMultiErrorが湧く。
+    起きるため２つ例外が湧く。
     '''
     import asyncgui as ag
 

--- a/tests/structured_concurrency/wait_any/test_simple_situation.py
+++ b/tests/structured_concurrency/wait_any/test_simple_situation.py
@@ -300,3 +300,49 @@ class Test_disable_cancellation:
         assert not main_task.cancelled
         e.set()
         assert main_task.cancelled
+
+
+def test_no_errors_on_GeneratorExit():
+    import asyncgui as ag
+
+    async def main():
+        try:
+            await ag.wait_any(ag.sleep_forever())
+        except GeneratorExit:
+            nonlocal caught; caught = True
+            raise
+
+    caught = False
+    task = ag.start(main())
+    task.root_coro.close()
+    assert caught
+    assert task.cancelled
+
+
+def test_error_on_scoped_cancel():
+    import asyncgui as ag
+
+    async def main():
+        async with ag.open_cancel_scope() as scope:
+            with pytest.raises(ag.ExceptionGroup) as exc_info:
+                scope.cancel()
+                await ag.wait_any(fail_on_cancel())
+            assert [ZeroDivisionError, ] == [type(e) for e in exc_info.value.exceptions]
+            await ag.sleep_forever()
+            pytest.fail()
+
+    task = ag.start(main())
+    assert task.finished
+
+
+def test_no_errors_on_scoped_cancel():
+    import asyncgui as ag
+
+    async def main():
+        async with ag.open_cancel_scope() as scope:
+            scope.cancel()
+            await ag.wait_any(ag.sleep_forever())
+            pytest.fail()
+
+    task = ag.start(main())
+    assert task.finished

--- a/tests/structured_concurrency/wait_any/test_simple_situation.py
+++ b/tests/structured_concurrency/wait_any/test_simple_situation.py
@@ -200,16 +200,14 @@ def test_必ず例外を起こす子_を複数持つ親を中断():
     import asyncgui as ag
     TS = ag.TaskState
 
-    async def main(e):
+    async def main():
         with pytest.raises(ag.ExceptionGroup) as excinfo:
             await ag.wait_any(fail_on_cancel(), fail_on_cancel())
         assert [ZeroDivisionError, ZeroDivisionError] == [type(e) for e in excinfo.value.exceptions]
-        await e.wait()
+        await ag.sleep_forever()
         pytest.fail("Failed to cancel")
 
-    e = ag.Event()
-    main_task = ag.Task(main(e))
-    ag.start(main_task)
+    main_task = ag.start(main())
     assert main_task.state is TS.STARTED
     main_task.cancel()
     assert main_task.state is TS.CANCELLED

--- a/tests/test_core_cancel_scope.py
+++ b/tests/test_core_cancel_scope.py
@@ -1,0 +1,366 @@
+import pytest
+
+
+def test_no_cancel():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        async with ag.open_cancel_scope() as scope:
+            assert scope._depth == 1
+            assert scope._task is task
+            assert not scope.cancelled_caught
+            assert not scope.cancell_called
+            assert not scope.closed
+            assert task._cancel_depth == 1
+            assert task._cancel_level is None
+        assert scope._depth == 1
+        assert scope._task is None
+        assert not scope.cancelled_caught
+        assert not scope.cancell_called
+        assert scope.closed
+        assert task._cancel_depth == 0
+        assert task._cancel_level is None
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+def test_cancel():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        async with ag.open_cancel_scope() as scope:
+            assert scope._depth == 1
+            assert scope._task is task
+            assert not scope.cancelled_caught
+            assert not scope.cancell_called
+            assert not scope.closed
+            assert task._cancel_depth == 1
+            assert task._cancel_level is None
+            scope.cancel()
+            assert scope._depth == 1
+            assert scope._task is task
+            assert not scope.cancelled_caught
+            assert scope.cancell_called
+            assert not scope.closed
+            assert task._cancel_depth == 1
+            assert task._cancel_level == 1
+
+            await ag.sleep_forever()
+            pytest.fail("Failed to cancel")
+        assert scope._depth == 1
+        assert scope._task is None
+        assert scope.cancelled_caught
+        assert scope.cancell_called
+        assert scope.closed
+        assert task._cancel_depth == 0
+        assert task._cancel_level is None
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+def test_cancel_neither():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        async with ag.open_cancel_scope() as o_scope:  # o_ -> outer
+            assert o_scope._depth == 1
+            assert o_scope._task is task
+            assert not o_scope.cancelled_caught
+            assert not o_scope.cancell_called
+            assert not o_scope.closed
+            assert task._cancel_depth == 1
+            assert task._cancel_level is None
+            async with ag.open_cancel_scope() as i_scope:  # i_ -> inner
+                assert i_scope._depth == 2
+                assert i_scope._task is task
+                assert not i_scope.cancelled_caught
+                assert not i_scope.cancell_called
+                assert not i_scope.closed
+                assert o_scope._depth == 1
+                assert o_scope._task is task
+                assert not o_scope.cancelled_caught
+                assert not o_scope.cancell_called
+                assert not o_scope.closed
+                assert task._cancel_depth == 2
+                assert task._cancel_level is None
+            assert i_scope._depth == 2
+            assert i_scope._task is None
+            assert not i_scope.cancelled_caught
+            assert not i_scope.cancell_called
+            assert i_scope.closed
+            assert o_scope._depth == 1
+            assert o_scope._task is task
+            assert not o_scope.cancelled_caught
+            assert not o_scope.cancell_called
+            assert not o_scope.closed
+            assert task._cancel_depth == 1
+            assert task._cancel_level is None
+        assert i_scope._depth == 2
+        assert i_scope._task is None
+        assert not i_scope.cancelled_caught
+        assert not i_scope.cancell_called
+        assert i_scope.closed
+        assert o_scope._depth == 1
+        assert o_scope._task is None
+        assert not o_scope.cancelled_caught
+        assert not o_scope.cancell_called
+        assert o_scope.closed
+        assert task._cancel_depth == 0
+        assert task._cancel_level is None
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+def test_cancel_inner():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        async with ag.open_cancel_scope() as o_scope:
+            async with ag.open_cancel_scope() as i_scope:
+                i_scope.cancel()
+                assert i_scope._depth == 2
+                assert i_scope._task is task
+                assert not i_scope.cancelled_caught
+                assert i_scope.cancell_called
+                assert not i_scope.closed
+                assert o_scope._depth == 1
+                assert o_scope._task is task
+                assert not o_scope.cancelled_caught
+                assert not o_scope.cancell_called
+                assert not o_scope.closed
+                assert task._cancel_depth == 2
+                assert task._cancel_level == 2
+
+                await ag.sleep_forever()
+                pytest.fail("Failed to cancel")
+            assert i_scope._depth == 2
+            assert i_scope._task is None
+            assert i_scope.cancelled_caught
+            assert i_scope.cancell_called
+            assert i_scope.closed
+            assert o_scope._depth == 1
+            assert o_scope._task is task
+            assert not o_scope.cancelled_caught
+            assert not o_scope.cancell_called
+            assert not o_scope.closed
+            assert task._cancel_depth == 1
+            assert task._cancel_level is None
+        assert i_scope._depth == 2
+        assert i_scope._task is None
+        assert i_scope.cancelled_caught
+        assert i_scope.cancell_called
+        assert i_scope.closed
+        assert o_scope._depth == 1
+        assert o_scope._task is None
+        assert not o_scope.cancelled_caught
+        assert not o_scope.cancell_called
+        assert o_scope.closed
+        assert task._cancel_depth == 0
+        assert task._cancel_level is None
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+def test_cancel_outer():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        async with ag.open_cancel_scope() as o_scope:
+            async with ag.open_cancel_scope() as i_scope:
+                o_scope.cancel()
+                assert i_scope._depth == 2
+                assert i_scope._task is task
+                assert not i_scope.cancelled_caught
+                assert not i_scope.cancell_called
+                assert not i_scope.closed
+                assert o_scope._depth == 1
+                assert o_scope._task is task
+                assert not o_scope.cancelled_caught
+                assert o_scope.cancell_called
+                assert not o_scope.closed
+                assert task._cancel_depth == 2
+                assert task._cancel_level == 1
+
+                await ag.sleep_forever()
+                pytest.fail("Failed to cancel")
+            pytest.fail("Failed to cancel")
+        assert i_scope._depth == 2
+        assert i_scope._task is None
+        assert not i_scope.cancelled_caught
+        assert not i_scope.cancell_called
+        assert i_scope.closed
+        assert o_scope._depth == 1
+        assert o_scope._task is None
+        assert o_scope.cancelled_caught
+        assert o_scope.cancell_called
+        assert o_scope.closed
+        assert task._cancel_depth == 0
+        assert task._cancel_level is None
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+def test_cancel_inner_first():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        async with ag.open_cancel_scope() as o_scope:
+            async with ag.open_cancel_scope() as i_scope:
+                i_scope.cancel()
+                assert i_scope._depth == 2
+                assert i_scope._task is task
+                assert not i_scope.cancelled_caught
+                assert i_scope.cancell_called
+                assert not i_scope.closed
+                assert o_scope._depth == 1
+                assert o_scope._task is task
+                assert not o_scope.cancelled_caught
+                assert not o_scope.cancell_called
+                assert not o_scope.closed
+                assert task._cancel_depth == 2
+                assert task._cancel_level == 2
+                o_scope.cancel()
+                assert i_scope._depth == 2
+                assert i_scope._task is task
+                assert not i_scope.cancelled_caught
+                assert i_scope.cancell_called
+                assert not i_scope.closed
+                assert o_scope._depth == 1
+                assert o_scope._task is task
+                assert not o_scope.cancelled_caught
+                assert o_scope.cancell_called
+                assert not o_scope.closed
+                assert task._cancel_depth == 2
+                assert task._cancel_level == 1
+
+                await ag.sleep_forever()
+                pytest.fail("Failed to cancel")
+            pytest.fail("Failed to cancel")
+        assert i_scope._depth == 2
+        assert i_scope._task is None
+        assert not i_scope.cancelled_caught
+        assert i_scope.cancell_called
+        assert i_scope.closed
+        assert o_scope._depth == 1
+        assert o_scope._task is None
+        assert o_scope.cancelled_caught
+        assert o_scope.cancell_called
+        assert o_scope.closed
+        assert task._cancel_depth == 0
+        assert task._cancel_level is None
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+def test_cancel_outer_first():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        async with ag.open_cancel_scope() as o_scope:
+            async with ag.open_cancel_scope() as i_scope:
+                o_scope.cancel()
+                assert i_scope._depth == 2
+                assert i_scope._task is task
+                assert not i_scope.cancelled_caught
+                assert not i_scope.cancell_called
+                assert not i_scope.closed
+                assert o_scope._depth == 1
+                assert o_scope._task is task
+                assert not o_scope.cancelled_caught
+                assert o_scope.cancell_called
+                assert not o_scope.closed
+                assert task._cancel_depth == 2
+                assert task._cancel_level == 1
+                i_scope.cancel()
+                assert i_scope._depth == 2
+                assert i_scope._task is task
+                assert not i_scope.cancelled_caught
+                assert i_scope.cancell_called
+                assert not i_scope.closed
+                assert o_scope._depth == 1
+                assert o_scope._task is task
+                assert not o_scope.cancelled_caught
+                assert o_scope.cancell_called
+                assert not o_scope.closed
+                assert task._cancel_depth == 2
+                assert task._cancel_level == 1
+
+                await ag.sleep_forever()
+                pytest.fail("Failed to cancel")
+            pytest.fail("Failed to cancel")
+        assert i_scope._depth == 2
+        assert i_scope._task is None
+        assert not i_scope.cancelled_caught
+        assert i_scope.cancell_called
+        assert i_scope.closed
+        assert o_scope._depth == 1
+        assert o_scope._task is None
+        assert o_scope.cancelled_caught
+        assert o_scope.cancell_called
+        assert o_scope.closed
+        assert task._cancel_depth == 0
+        assert task._cancel_level is None
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+def test_reuse():
+    import asyncgui as ag
+
+    async def async_fn():
+        scope = ag.open_cancel_scope()
+        async with scope:
+            pass
+        async with scope:
+            pass
+
+    task = ag.start(async_fn())
+    assert task.finished
+
+
+@pytest.mark.xfail
+def test_reuse_the_internal_one():
+    import asyncgui as ag
+
+    async def async_fn():
+        task = await ag.current_task()
+        scope = ag.CancelScope(task)
+        with scope:
+            pass
+        with scope:
+            pass
+
+    task = ag.start(async_fn())
+
+
+@pytest.mark.parametrize('inside', (True, False, ))
+@pytest.mark.parametrize('outside', (True, False, ))
+def test_cancel_does_not_affect_the_next_scope(inside, outside):
+    import asyncgui as ag
+
+    if not (inside or outside):
+        return
+
+    async def async_fn():
+        async with ag.open_cancel_scope() as scope:
+            if inside: scope.cancel()
+        if outside: scope.cancel()
+        async with ag.open_cancel_scope() as scope:
+            await ag.sleep_forever()
+
+    task = ag.start(async_fn())
+    assert task.state is ag.TaskState.STARTED

--- a/tests/test_core_start.py
+++ b/tests/test_core_start.py
@@ -15,16 +15,12 @@ def test__unsupported_type():
             ag.start(v)
 
 
-def test__return_value():
+def test__return_value_is_a_Task():
     import asyncgui as ag
 
-    task = ag.Task(ag.sleep_forever())
-    gen_based_coro = ag.sleep_forever()
-    coro = async_fn()
-
-    assert ag.start(task) is task
-    for v in (gen_based_coro, coro):
-        assert isinstance(ag.start(v), ag.Task)
+    for v in [ag.Task(ag.sleep_forever()), ag.sleep_forever(), async_fn()]:
+        r = ag.start(v)
+        assert isinstance(r, ag.Task)
 
 
 def test__already_started():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_get_current_task():
+def test_current_task():
     import asyncgui as ag
     finished = False
 
@@ -47,17 +47,16 @@ def test_dummy_task():
 def test_check_cancellation(call_cancel, disable_cancellation):
     import asyncgui as ag
 
-    async def async_func(ctx):
+    async def async_func():
         if call_cancel:
-            ctx['task'].cancel()
+            task.cancel()
         if disable_cancellation:
             async with ag.disable_cancellation():
                 await ag.check_cancellation()
         else:
             await ag.check_cancellation()
 
-    ctx = {}
-    ctx['task'] = task = ag.Task(async_func(ctx))
+    task = ag.Task(async_func())
     ag.start(task)
     if (not disable_cancellation) and call_cancel:
         assert task.cancelled


### PR DESCRIPTION
A [trio.CancelScope](https://trio.readthedocs.io/en/stable/reference-core.html#trio.CancelScope) equivalent.

```python
import asyncgui as ag

async def async_fn():
    async with ag.open_cancel_scope() as scope:
        ...
        scope.cancel()
        await ag.sleep_forever()
        assert False, "won't reach here"
    assert True
```

It's nestable. (Same as Trio's)

```python
import asyncgui as ag

async def async_fn():
    async with ag.open_cancel_scope() as outer_scope:
        ...
        async with ag.open_cancel_scope() as inner_scope:
            ...
            outer_scope.cancel()
            await ag.sleep_forever()
            assert False, "won't reach here"
        assert False, "won't reach here"
    assert True
```