### PR TITLE
remove 'aclosing()'

### DIFF
--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -1,7 +1,7 @@
 __all__ = (
     'ExceptionGroup', 'BaseExceptionGroup', 'InvalidStateError', 'Cancelled',
     'Aw_or_Task', 'start', 'Task', 'TaskState', 'current_task', 'open_cancel_scope',
-    'aclosing', 'sleep_forever', 'Event', 'disable_cancellation', 'dummy_task', 'check_cancellation',
+    'sleep_forever', 'Event', 'disable_cancellation', 'dummy_task', 'check_cancellation',
     'wait_all', 'wait_any', 'run_and_cancelling',
 )
 import types
@@ -394,23 +394,6 @@ class Event:
             return self._value
         else:
             return (yield self._waiting_tasks.append)[0][0]
-
-
-class aclosing:
-    '''(experimental)
-    async version of 'contextlib.closing()'.
-    '''
-
-    __slots__ = ('_agen', )
-
-    def __init__(self, agen):
-        self._agen = agen
-
-    async def __aenter__(self):
-        return self._agen
-
-    async def __aexit__(self, *__):
-        await self._agen.aclose()
 
 
 dummy_task = Task(sleep_forever(), name='asyncgui.dummy_task')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,29 +14,6 @@ def test_current_task():
     assert finished
 
 
-def test_aclosing():
-    import asyncgui as ag
-    agen_closed = False
-
-    async def agen_func():
-        try:
-            for i in range(10):
-                yield i
-        finally:
-            nonlocal agen_closed;agen_closed = True
-
-    async def async_fn():
-        async with ag.aclosing(agen_func()) as agen:
-            async for i in agen:
-                if i > 1:
-                    break
-            assert not agen_closed
-        assert agen_closed
-
-    task = ag.start(async_fn())
-    assert task.finished
-
-
 def test_dummy_task():
     from asyncgui import dummy_task
     assert dummy_task.cancelled


### PR DESCRIPTION
It's no longer necessary because of [contextlib.aclosing](https://docs.python.org/3/library/contextlib.html#contextlib.aclosing).