### PR TITLE
make Task not weak-reference-able

### DIFF
--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -57,7 +57,7 @@ class Task:
     __slots__ = (
         'name', '_uid', '_root_coro', '_state', '_result', '_on_end',
         'userdata', '_exception', '_suppresses_exception',
-        '_disable_cancellation', '_cancel_depth', '_cancel_level', '__weakref__',
+        '_disable_cancellation', '_cancel_depth', '_cancel_level',
     )
 
     _uid_iter = itertools.count()

--- a/tests/test_core_Task.py
+++ b/tests/test_core_Task.py
@@ -268,10 +268,8 @@ def test_try_to_cancel_self_but_no_opportunity_for_that():
     assert task.finished
 
 
+@pytest.mark.xfail
 def test_weakref():
     import weakref
     import asyncgui as ag
-
-    task = ag.Task(ag.sleep_forever())
-    weakref.ref(task)
-    task.cancel()
+    weakref.ref(ag.dummy_task)


### PR DESCRIPTION
Taskへの参照が無くなるとその後Taskが持つcoro内でGeneratorExitが起きて中断が起こるが、GeneratorExitは融通が利かず中断作業の邪魔をすることがあるのでそもそも起こらないようにすべきだと思う。なのでそれを誘発する弱参照を禁ずる。