### PR TITLE
make Event unable to pass a value

### DIFF
--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -365,7 +365,7 @@ class Event:
         any_library.register_callback(e.set)
     '''
 
-    __slots__ = ('_flag', '_waiting_tasks', '__weakref__', )
+    __slots__ = ('_flag', '_waiting_tasks', )
 
     def __init__(self):
         self._flag = False

--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -381,15 +381,22 @@ class Event:
         tasks = self._waiting_tasks
         self._waiting_tasks = []
         for t in tasks:
-            t._step()
+            if t is not None:
+                t._step()
 
     def clear(self):
         self._flag = False
 
     @types.coroutine
     def wait(self):
-        if not self._flag:
+        if self._flag:
+            return
+        try:
+            tasks = self._waiting_tasks
+            idx = len(tasks)
             yield self._waiting_tasks.append
+        finally:
+            tasks[idx] = None
 
 
 async def wait_all(*aws: T.Iterable[Aw_or_Task]) -> T.Awaitable[T.List[Task]]:  # noqa: C901

--- a/tests/utils/test_Event.py
+++ b/tests/utils/test_Event.py
@@ -51,10 +51,3 @@ def test_clear():
     assert task_state == 'C'
     e1.set()
     assert task_state == 'D'
-
-
-def test_weakref():
-    import weakref
-    from asyncgui import Event
-    e = Event()
-    weakref.ref(e)

--- a/tests/utils/test_Event.py
+++ b/tests/utils/test_Event.py
@@ -53,51 +53,6 @@ def test_clear():
     assert task_state == 'D'
 
 
-def test_pass_argument():
-    import asyncgui as ag
-    e = ag.Event()
-
-    async def main(e):
-        assert await e.wait() == 'A'
-
-    task = ag.start(main(e))
-    assert not task.finished
-    e.set('A')
-    assert task.finished
-
-
-def test_reset_value():
-    import asyncgui as ag
-    e = ag.Event()
-
-    async def async_fn1(e):
-        assert await e.wait() == 'A'
-        e.clear()
-        e.set('B')
-
-    async def async_fn2(e):
-        assert await e.wait() == 'A'
-        assert await e.wait() == 'B'
-
-    task1 = ag.start(async_fn1(e))
-    task2 = ag.start(async_fn2(e))
-    assert not task1.finished
-    assert not task2.finished
-    e.set('A')
-    assert task1.finished
-    assert task2.finished
-
-
-def test_regular_gen():
-    import asyncgui as ag
-
-    def regular_gen():
-        yield 1
-
-    with pytest.raises(ValueError):
-        ag.start(regular_gen())
-
-
 def test_weakref():
     import weakref
     from asyncgui import Event

--- a/tests/utils/test_Event.py
+++ b/tests/utils/test_Event.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_multiple_tasks():
+def test_wait_then_set():
     import asyncgui as ag
     TS = ag.TaskState
     e = ag.Event()
@@ -14,16 +14,15 @@ def test_multiple_tasks():
     assert task2.state is TS.FINISHED
 
 
-def test_set_before_task_starts():
+def test_set_then_wait():
     import asyncgui as ag
+    TS = ag.TaskState
     e = ag.Event()
     e.set()
-
-    async def main():
-        await e.wait()
-
-    task = ag.start(main())
-    assert task.finished
+    task1 = ag.start(e.wait())
+    task2 = ag.start(e.wait())
+    assert task1.state is TS.FINISHED
+    assert task2.state is TS.FINISHED
 
 
 def test_clear():
@@ -47,6 +46,7 @@ def test_clear():
     e1.set()
     assert task_state == 'B'
     e1.clear()
+    assert task_state == 'B'
     e2.set()
     assert task_state == 'C'
     e1.set()


### PR DESCRIPTION
We can pass a value through an Event:

```python
import asyncgui as ag

e = ag.Event()

async def async_fn():
    assert await e.wait() == 'A'

ag.start(async_fn())
e.set('A')
```

This pr makes it impossible.
