### PR TITLE
add TaskCounter

### DIFF
--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -1,9 +1,19 @@
 __all__ = (
+    # core (exceptions)
     'ExceptionGroup', 'BaseExceptionGroup', 'InvalidStateError', 'Cancelled',
+
+    # core
     'Aw_or_Task', 'start', 'Task', 'TaskState', 'current_task', 'open_cancel_scope', 'CancelScope',
-    'sleep_forever', 'Event', 'disable_cancellation', 'dummy_task', 'check_cancellation',
-    'wait_all', 'wait_any', 'run_and_cancelling',
-    'IBox', 'ISignal', 
+    'sleep_forever', 'disable_cancellation', 'dummy_task', 'check_cancellation',
+
+    # utils
+    'Event',
+
+    # utils (structured concurrency)
+    'wait_all', 'wait_any', 'wait_all_cm', 'wait_any_cm', 'run_as_secondary', 'run_as_primary',
+
+    # utils (for async library developer)
+    'IBox', 'ISignal',
 )
 import types
 import typing as T
@@ -566,7 +576,10 @@ async def _wait_xxx_cm(debug_msg, on_child_end, wait_bg, aw: Aw_or_Task):
 
 
 _wait_xxx_cm_type = T.Callable[[Aw_or_Task], T.AsyncContextManager[Task]]
-run_and_cancelling: _wait_xxx_cm_type = partial(_wait_xxx_cm, "run_and_cancelling()", _on_child_end__ver_all, False)
+wait_all_cm: _wait_xxx_cm_type = partial(_wait_xxx_cm, "wait_all_cm()", _on_child_end__ver_all, True)
+wait_any_cm: _wait_xxx_cm_type = partial(_wait_xxx_cm, "wait_any_cm()", _on_child_end__ver_any, False)
+run_as_primary: _wait_xxx_cm_type = partial(_wait_xxx_cm, "run_as_primary()", _on_child_end__ver_any, True)
+run_as_secondary: _wait_xxx_cm_type = partial(_wait_xxx_cm, "run_as_secondary()", _on_child_end__ver_all, False)
 
 
 class IBox:
@@ -578,7 +591,7 @@ class IBox:
 
     .. note::
 
-        This exists for the purpose of building an async/await-based api from a callback-based api.
+        This exists for the purpose of wrapping a callback-based api in an async/await-based api.
         Using it for any other purpose is not recommended.
     '''
 

--- a/tests/utils/test_TaskCounter.py
+++ b/tests/utils/test_TaskCounter.py
@@ -1,0 +1,89 @@
+import pytest
+
+
+def test_wait():
+    import asyncgui as ag
+
+    tc = ag.TaskCounter()
+    task = ag.start(tc.to_be_zero())
+    assert task.finished
+
+
+def test_decr_decr():
+    import asyncgui as ag
+
+    tc = ag.TaskCounter()
+    with pytest.raises(AssertionError):
+        tc.decrease()
+    with pytest.raises(AssertionError):
+        tc.decrease()
+    assert tc._n_tasks == 0
+
+
+def test_incr_wait_decr():
+    import asyncgui as ag
+
+    tc = ag.TaskCounter()
+    tc.increase()
+    task = ag.start(tc.to_be_zero())
+    assert not task.finished
+    tc.decrease()
+    assert task.finished
+
+
+def test_incr_decr_wait():
+    import asyncgui as ag
+
+    tc = ag.TaskCounter()
+    tc.increase()
+    tc.decrease()
+    task = ag.start(tc.to_be_zero())
+    assert task.finished
+
+
+def test_incr_decr_incr_wait_decr():
+    import asyncgui as ag
+
+    tc = ag.TaskCounter()
+    tc.increase()
+    tc.decrease()
+    tc.increase()
+    task = ag.start(tc.to_be_zero())
+    assert not task.finished
+    tc.decrease()
+    assert task.finished
+
+
+def test_boolean():
+    import asyncgui as ag
+
+    tc = ag.TaskCounter()
+    assert not tc
+    tc.increase()
+    assert tc
+    tc.decrease()
+    assert not tc
+
+
+def test_cancel():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn(ctx, tc):
+        async with ag.open_cancel_scope() as scope:
+            ctx['scope'] = scope
+            await tc.to_be_zero()
+            pytest.fail()
+        await ag.sleep_forever()
+
+    ctx = {}
+    tc = ag.TaskCounter()
+    tc.increase()
+    task = ag.start(async_fn(ctx, tc))
+    assert task.state is TS.STARTED
+    ctx['scope'].cancel()
+    assert task.state is TS.STARTED
+    tc.decrease()
+    assert task.state is TS.STARTED
+    task._step()
+    assert task.state is TS.FINISHED

--- a/tests/utils/test_run_and_cancelling.py
+++ b/tests/utils/test_run_and_cancelling.py
@@ -1,19 +1,22 @@
+'''
+例外が起きる状況のテストは全て test_wait_xxx_cm.py に任せてあるので、ここではそれ以外の状況のみをテストする。
+'''
+
 import pytest
 
 
 def test_bg_finishes_immediately():
     import asyncgui as ag
-    TS = ag.TaskState
 
-    async def do_nothing():
+    async def finish_imm():
         pass
 
     async def async_fn():
-        async with ag.run_and_cancelling(do_nothing()) as bg_task:
-            assert bg_task.state is TS.FINISHED
+        async with ag.run_and_cancelling(finish_imm()) as bg_task:
+            assert bg_task.finished
 
     fg_task = ag.start(async_fn())
-    assert fg_task.state is TS.FINISHED
+    assert fg_task.finished
 
 
 def test_bg_finishes_while_fg_is_running():
@@ -89,206 +92,21 @@ def test_fg_finishes_while_bg_is_suspended():
     assert fg_task.state is TS.FINISHED
 
 
-def test_bg_fails_immediately():
-    import asyncgui as ag
-
-    async def fails_imm():
-        raise ZeroDivisionError
-
-    async def async_fn():
-        bg_task = ag.Task(fails_imm())
-        with pytest.raises(ZeroDivisionError):
-            async with ag.run_and_cancelling(bg_task):
-                pytest.fail()
-            pytest.fail()
-        assert type(bg_task._exc_caught) is ZeroDivisionError
-
-    fg_task = ag.start(async_fn())
-    assert fg_task.finished
-
-
-def test_bg_fails_while_fg_is_suspended():
+def test_fg_finishes_while_bg_is_protected():
     import asyncgui as ag
     TS = ag.TaskState
 
-    async def fails_soon(e):
-        await e.wait()
-        raise ZeroDivisionError
+    async def bg_func():
+        async with ag.disable_cancellation():
+            await e.wait()
 
-    async def async_fn(e):
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(fails_soon(e)) as bg_task:
-                assert bg_task.state is TS.STARTED
-                await ag.sleep_forever()
-                pytest.fail()
-            pytest.fail()
-        assert [ZeroDivisionError, ] == [type(e) for e in excinfo.value.exceptions]
+    async def async_fn():
+        async with ag.run_and_cancelling(bg_func()) as bg_task:
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.FINISHED
 
     e = ag.Event()
-    fg_task = ag.start(async_fn(e))
+    fg_task = ag.start(async_fn())
     assert fg_task.state is TS.STARTED
     e.set()
     assert fg_task.state is TS.FINISHED
-
-
-def test_bg_fails_while_fg_is_running():
-    import asyncgui as ag
-    TS = ag.TaskState
-
-    async def fails_soon():
-        await ag.sleep_forever()
-        raise ZeroDivisionError
-
-    async def async_fn():
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(fails_soon()) as bg_task:
-                assert bg_task.state is TS.STARTED
-                bg_task._step()
-                assert bg_task.state is TS.CANCELLED
-                assert type(bg_task._exc_caught) is ZeroDivisionError
-                await ag.sleep_forever()
-                pytest.fail()
-            pytest.fail()
-        assert [ZeroDivisionError, ] == [type(e) for e in excinfo.value.exceptions]
-
-    fg_task = ag.start(async_fn())
-    assert fg_task.state is TS.FINISHED
-
-
-def test_fg_fails_while_bg_is_suspended():
-    import asyncgui as ag
-    TS = ag.TaskState
-
-    async def async_fn():
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(ag.sleep_forever()) as bg_task:
-                raise ZeroDivisionError
-            pytest.fail()
-        assert bg_task.cancelled
-        assert bg_task._exc_caught is None
-        assert [ZeroDivisionError, ] == [type(e) for e in excinfo.value.exceptions]
-
-    fg_task = ag.start(async_fn())
-    assert fg_task.finished
-
-
-def test_fg_fails_and_bg_fails():
-    import asyncgui as ag
-
-    async def bg_func():
-        await e.wait()
-        fg_task._step()
-        raise ZeroDivisionError
-
-    async def async_fn():
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(bg_func()):
-                await ag.sleep_forever()
-                raise ZeroDivisionError
-            pytest.fail()
-        assert [ZeroDivisionError, ] * 2 == [type(e) for e in excinfo.value.exceptions]
-
-    e = ag.Event()
-    fg_task = ag.start(async_fn())
-    e.set()
-    assert fg_task.finished
-
-
-def test_bg_fails_and_fg_fails():
-    import asyncgui as ag
-
-    async def bg_func():
-        await ag.sleep_forever()
-        raise ZeroDivisionError
-
-    async def async_fn():
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(bg_func()) as bg_task:
-                bg_task._step()
-                raise ZeroDivisionError
-            pytest.fail()
-        assert [ZeroDivisionError, ] * 2 == [type(e) for e in excinfo.value.exceptions]
-
-    fg_task = ag.start(async_fn())
-    assert fg_task.finished
-
-
-def test_fg_fails_and_bg_fails_on_cancel():
-    import asyncgui as ag
-
-    async def fails_eventually():
-        try:
-            await ag.sleep_forever()
-        finally:
-            raise ZeroDivisionError
-
-    async def async_fn():
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(fails_eventually()):
-                raise ZeroDivisionError
-            pytest.fail()
-        assert [ZeroDivisionError, ] * 2 == [type(e) for e in excinfo.value.exceptions]
-
-    fg_task = ag.start(async_fn())
-    assert fg_task.finished
-
-
-def test_bg_fails_and_fg_fails_on_cancel():
-    import asyncgui as ag
-
-    async def bg_func():
-        await e.wait()
-        raise ZeroDivisionError
-
-    async def async_fn():
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(bg_func()):
-                try:
-                    await ag.sleep_forever()
-                finally:
-                    raise ZeroDivisionError
-            pytest.fail()
-        assert [ZeroDivisionError, ] * 2 == [type(e) for e in excinfo.value.exceptions]
-
-    e = ag.Event()
-    fg_task = ag.start(async_fn())
-    e.set()
-    assert fg_task.finished
-
-
-def test_bg_fails_after_fg_finishes():
-    import asyncgui as ag
-
-    async def bg_func():
-        await e.wait()
-        fg_task._step()
-        raise ZeroDivisionError
-
-    async def async_fn():
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(bg_func()):
-                await ag.sleep_forever()
-            pytest.fail()
-        assert [ZeroDivisionError, ] == [type(e) for e in excinfo.value.exceptions]
-
-    e = ag.Event()
-    fg_task = ag.start(async_fn())
-    e.set()
-    assert fg_task.finished
-
-
-def test_fg_fails_after_bg_finishes():
-    import asyncgui as ag
-
-    async def async_fn():
-        fg_task = await ag.current_task()
-        with pytest.raises(ag.ExceptionGroup) as excinfo:
-            async with ag.run_and_cancelling(ag.sleep_forever()) as bg_task:
-                bg_task._step()
-                assert bg_task.finished
-                raise ZeroDivisionError
-            pytest.fail()
-        assert [ZeroDivisionError, ] == [type(e) for e in excinfo.value.exceptions]
-
-    fg_task = ag.start(async_fn())
-    assert fg_task.finished

--- a/tests/utils/test_run_as_primary.py
+++ b/tests/utils/test_run_as_primary.py
@@ -1,0 +1,118 @@
+'''
+例外が起きる状況のテストは全て test_wait_xxx_cm.py に任せてあるので、ここではそれ以外の状況のみをテストする。
+'''
+
+import pytest
+
+fg_sleep = pytest.mark.parametrize('fg_sleep', (True, False, ), ids=('fg_sleep', ''))
+
+@fg_sleep
+def test_bg_finishes_immediately(fg_sleep):
+    import asyncgui as ag
+
+    async def finish_imm():
+        pass
+
+    async def async_fn():
+        async with ag.run_as_primary(finish_imm()) as bg_task:
+            assert bg_task.finished
+            if fg_sleep:
+                await ag.sleep_forever()
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.finished
+
+
+@fg_sleep
+def test_bg_finishes_while_fg_is_running(fg_sleep):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.run_as_primary(ag.sleep_forever()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            bg_task._step()
+            assert bg_task.state is TS.FINISHED
+            if fg_sleep:
+                await ag.sleep_forever()
+        assert bg_task.state is TS.FINISHED
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_finishes_while_fg_is_suspended():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.run_as_primary(e.wait()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            await ag.sleep_forever()
+            pytest.fail()
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_running():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_fn():
+        await e.wait()
+        fg_task._step()
+
+    async def async_fn():
+        async with ag.run_as_primary(bg_fn()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            await ag.sleep_forever()
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_suspended():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.run_as_primary(e.wait()) as bg_task:
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.FINISHED
+        
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_finishes_while_fg_is_protected():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.run_as_primary(e.wait()) as bg_task:
+            async with ag.disable_cancellation():
+                await ag.sleep_forever()
+            assert bg_task.state is TS.FINISHED
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED

--- a/tests/utils/test_run_as_secondary.py
+++ b/tests/utils/test_run_as_secondary.py
@@ -1,0 +1,112 @@
+'''
+例外が起きる状況のテストは全て test_wait_xxx_cm.py に任せてあるので、ここではそれ以外の状況のみをテストする。
+'''
+
+import pytest
+
+
+def test_bg_finishes_immediately():
+    import asyncgui as ag
+
+    async def finish_imm():
+        pass
+
+    async def async_fn():
+        async with ag.run_as_secondary(finish_imm()) as bg_task:
+            assert bg_task.finished
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.finished
+
+
+def test_bg_finishes_while_fg_is_running():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.run_as_secondary(ag.sleep_forever()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            bg_task._step()
+            assert bg_task.state is TS.FINISHED
+        assert bg_task.state is TS.FINISHED
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_finishes_while_fg_is_suspended():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.run_as_secondary(e.wait()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            await ag.sleep_forever()
+            assert bg_task.state is TS.FINISHED
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED
+
+
+@pytest.mark.parametrize('bg_cancel', (True, False, ))
+def test_fg_finishes_while_bg_is_running(bg_cancel):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_fn():
+        await e.wait()
+        fg_task._step()
+        if bg_cancel:
+            await ag.sleep_forever()
+
+    async def async_fn(e):
+        async with ag.run_as_secondary(bg_fn()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            await ag.sleep_forever()
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is (TS.CANCELLED if bg_cancel else TS.FINISHED)
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn(e))
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_suspended():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.run_as_secondary(ag.sleep_forever()) as bg_task:
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.CANCELLED
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_protected():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_func():
+        async with ag.disable_cancellation():
+            await e.wait()
+
+    async def async_fn():
+        async with ag.run_as_secondary(bg_func()) as bg_task:
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED

--- a/tests/utils/test_wait_all_cm.py
+++ b/tests/utils/test_wait_all_cm.py
@@ -1,0 +1,139 @@
+'''
+例外が起きる状況のテストは全て test_wait_xxx_cm.py に任せてあるので、ここではそれ以外の状況のみをテストする。
+'''
+
+import pytest
+
+
+def test_bg_finishes_immediately():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def finish_imm():
+        pass
+
+    async def async_fn():
+        async with ag.wait_all_cm(finish_imm()) as bg_task:
+            assert bg_task.state is TS.FINISHED
+            await ag.sleep_forever()
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_finishes_while_fg_is_running():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.wait_all_cm(ag.sleep_forever()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            bg_task._step()
+            assert bg_task.state is TS.FINISHED
+            await ag.sleep_forever()
+        assert bg_task.state is TS.FINISHED
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_finishes_while_fg_is_suspended():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.wait_all_cm(e.wait()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            await ag.sleep_forever()
+            assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_running():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_fn():
+        await e.wait()
+        fg_task._step()
+
+    async def async_fn(e):
+        async with ag.wait_all_cm(bg_fn()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            await ag.sleep_forever()
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn(e))
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_suspended():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.wait_all_cm(e.wait()) as bg_task:
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.FINISHED
+        
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_finishes_while_fg_is_protected():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.wait_all_cm(e.wait()) as bg_task:
+            async with ag.disable_cancellation():
+                await ag.sleep_forever()
+            assert bg_task.state is TS.FINISHED
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_protected():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_func():
+        async with ag.disable_cancellation():
+            await e.wait()
+
+    async def async_fn():
+        async with ag.wait_all_cm(bg_func()) as bg_task:
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED

--- a/tests/utils/test_wait_any_cm.py
+++ b/tests/utils/test_wait_any_cm.py
@@ -4,30 +4,38 @@
 
 import pytest
 
+fg_sleep = pytest.mark.parametrize('fg_sleep', (True, False, ), ids=('fg_sleep', ''))
+bg_sleep = pytest.mark.parametrize('bg_sleep', (True, False, ), ids=('bg_sleep', ''))
 
-def test_bg_finishes_immediately():
+@fg_sleep
+def test_bg_finishes_immediately(fg_sleep):
     import asyncgui as ag
 
     async def finish_imm():
         pass
 
     async def async_fn():
-        async with ag.run_and_cancelling(finish_imm()) as bg_task:
+        async with ag.wait_any_cm(finish_imm()) as bg_task:
             assert bg_task.finished
+            if fg_sleep:
+                await ag.sleep_forever()
 
     fg_task = ag.start(async_fn())
     assert fg_task.finished
 
 
-def test_bg_finishes_while_fg_is_running():
+@fg_sleep
+def test_bg_finishes_while_fg_is_running(fg_sleep):
     import asyncgui as ag
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_and_cancelling(ag.sleep_forever()) as bg_task:
+        async with ag.wait_any_cm(ag.sleep_forever()) as bg_task:
             assert bg_task.state is TS.STARTED
             bg_task._step()
             assert bg_task.state is TS.FINISHED
+            if fg_sleep:
+                await ag.sleep_forever()
         assert bg_task.state is TS.FINISHED
 
     fg_task = ag.start(async_fn())
@@ -39,9 +47,66 @@ def test_bg_finishes_while_fg_is_suspended():
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_and_cancelling(e.wait()) as bg_task:
+        async with ag.wait_any_cm(e.wait()) as bg_task:
             assert bg_task.state is TS.STARTED
             await ag.sleep_forever()
+            pytest.fail()
+        assert bg_task.state is TS.FINISHED
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+@bg_sleep
+def test_fg_finishes_while_bg_is_running(bg_sleep):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_fn():
+        await e.wait()
+        fg_task._step()
+        if bg_sleep:
+            await ag.sleep_forever()
+
+    async def async_fn():
+        async with ag.wait_any_cm(bg_fn()) as bg_task:
+            assert bg_task.state is TS.STARTED
+            await ag.sleep_forever()
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is (TS.CANCELLED if bg_sleep else TS.FINISHED)
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_finishes_while_bg_is_suspended():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.wait_any_cm(ag.sleep_forever()) as bg_task:
+            assert bg_task.state is TS.STARTED
+        assert bg_task.state is TS.CANCELLED
+        
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_finishes_while_fg_is_protected():
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.wait_any_cm(e.wait()) as bg_task:
+            async with ag.disable_cancellation():
+                await ag.sleep_forever()
             assert bg_task.state is TS.FINISHED
         assert bg_task.state is TS.FINISHED
 
@@ -54,44 +119,6 @@ def test_bg_finishes_while_fg_is_suspended():
     assert fg_task.state is TS.FINISHED
 
 
-@pytest.mark.parametrize('bg_cancel', (True, False, ))
-def test_fg_finishes_while_bg_is_running(bg_cancel):
-    import asyncgui as ag
-    TS = ag.TaskState
-
-    async def bg_fn():
-        await e.wait()
-        fg_task._step()
-        if bg_cancel:
-            await ag.sleep_forever()
-
-    async def async_fn(e):
-        async with ag.run_and_cancelling(bg_fn()) as bg_task:
-            assert bg_task.state is TS.STARTED
-            await ag.sleep_forever()
-            assert bg_task.state is TS.STARTED
-        assert bg_task.state is (TS.CANCELLED if bg_cancel else TS.FINISHED)
-
-    e = ag.Event()
-    fg_task = ag.start(async_fn(e))
-    assert fg_task.state is TS.STARTED
-    e.set()
-    assert fg_task.state is TS.FINISHED
-
-
-def test_fg_finishes_while_bg_is_suspended():
-    import asyncgui as ag
-    TS = ag.TaskState
-
-    async def async_fn():
-        async with ag.run_and_cancelling(ag.sleep_forever()) as bg_task:
-            assert bg_task.state is TS.STARTED
-        assert bg_task.state is TS.CANCELLED
-
-    fg_task = ag.start(async_fn())
-    assert fg_task.state is TS.FINISHED
-
-
 def test_fg_finishes_while_bg_is_protected():
     import asyncgui as ag
     TS = ag.TaskState
@@ -101,7 +128,7 @@ def test_fg_finishes_while_bg_is_protected():
             await e.wait()
 
     async def async_fn():
-        async with ag.run_and_cancelling(bg_func()) as bg_task:
+        async with ag.wait_any_cm(bg_func()) as bg_task:
             assert bg_task.state is TS.STARTED
         assert bg_task.state is TS.FINISHED
 

--- a/tests/utils/test_wait_xxx_cm.py
+++ b/tests/utils/test_wait_xxx_cm.py
@@ -1,0 +1,500 @@
+import pytest
+
+
+@pytest.fixture(scope='module', params=('wait_all_cm', 'wait_any_cm',  'run_as_secondary', 'run_as_primary', ))
+def any_cm(request):
+    import asyncgui
+    return getattr(asyncgui, request.param)
+
+
+@pytest.fixture(scope='module', params=('wait_any_cm',  'run_as_secondary', ))
+def fg_primary_cm(request):
+    import asyncgui
+    return getattr(asyncgui, request.param)
+
+
+@pytest.fixture(scope='module', params=('wait_any_cm',  'run_as_primary', ))
+def bg_primary_cm(request):
+    import asyncgui
+    return getattr(asyncgui, request.param)
+
+
+def test_bg_fails_immediately(any_cm):
+    import asyncgui as ag
+
+    async def fail_imm():
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_imm()):
+                pytest.fail()
+            pytest.fail()
+        assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.finished
+
+
+def test_bg_fails_while_fg_is_suspended(any_cm):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def fail_soon():
+        await e.wait()
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_soon()) as bg_task:
+                assert bg_task.state is TS.STARTED
+                await ag.sleep_forever()
+                pytest.fail()
+            pytest.fail()
+        assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_bg_fails_while_fg_is_running(any_cm):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def fail_soon():
+        await ag.sleep_forever()
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_soon()) as bg_task:
+                assert bg_task.state is TS.STARTED
+                bg_task._step()
+                assert bg_task.state is TS.CANCELLED
+                await ag.sleep_forever()
+                pytest.fail()
+            pytest.fail()
+        assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_fails_while_bg_is_suspended(any_cm):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(ag.sleep_forever()) as bg_task:
+                raise ZeroDivisionError
+            pytest.fail()
+        assert bg_task.cancelled
+        assert bg_task._exc_caught is None
+        assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.finished
+
+
+def test_fg_fails_while_bg_is_running(any_cm):
+    import asyncgui as ag
+
+    async def bg_func():
+        await e.wait()
+        fg_task._step()
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(bg_func()) as bg_task:
+                await ag.sleep_forever()
+                raise ZeroDivisionError
+            pytest.fail()
+        assert bg_task.finished
+        assert bg_task._exc_caught is None
+        assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    e.set()
+    assert fg_task.finished
+
+
+def test_bg_fails_after_fg_finishes(any_cm):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def fail_soon():
+        async with ag.disable_cancellation():
+            await e.wait()
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_soon()) as bg_task:
+                assert bg_task.state is TS.STARTED
+            pytest.fail()
+        assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.STARTED
+    e.set()
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_fails_after_bg_finishes(any_cm):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def finish_imm():
+        pass
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(finish_imm()) as bg_task:
+                raise ZeroDivisionError
+            pytest.fail()
+        assert bg_task.finished
+        assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.state is TS.FINISHED
+
+
+def test_fg_fails_then_bg_fails_1(any_cm):
+    # 裏が停止 -> 表で例外 -> 裏を中断 -> 裏で例外
+    import asyncgui as ag
+
+    async def fail_eventually():
+        try:
+            await ag.sleep_forever()
+        finally:
+            raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_eventually()):
+                raise ZeroDivisionError
+            pytest.fail()
+        assert [ZeroDivisionError, ] * 2 == [type(exc) for exc in excinfo.value.exceptions]
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.finished
+
+
+def test_fg_fails_then_bg_fails_2(any_cm):
+    # 裏が停止 -> 表で例外 -> 裏は保護下 -> 発火 -> 裏で例外
+    import asyncgui as ag
+
+    async def bg_func():
+        async with ag.disable_cancellation():
+            await e.wait()
+            raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(bg_func()):
+                raise ZeroDivisionError
+            pytest.fail()
+        assert [ZeroDivisionError, ] * 2 == [type(exc) for exc in excinfo.value.exceptions]
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert not fg_task.finished
+    e.set()
+    assert fg_task.finished
+
+
+def test_fg_fails_then_bg_fails_3(any_cm):
+    # 裏が停止 -> 表が停止 -> 発火 -> 表で例外 -> 裏で例外
+    import asyncgui as ag
+
+    async def bg_func():
+        await e.wait()
+        fg_task._step()
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(bg_func()):
+                await ag.sleep_forever()
+                raise ZeroDivisionError
+            pytest.fail()
+        assert [ZeroDivisionError, ] * 2 == [type(exc) for exc in excinfo.value.exceptions]
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert not fg_task.finished
+    e.set()
+    assert fg_task.finished
+
+
+def test_bg_fails_then_fg_fails_1(any_cm):
+    # 裏が停止 -> 表が裏を再開 -> 裏で例外 -> 表で例外
+    import asyncgui as ag
+
+    async def fail_soon():
+        await ag.sleep_forever()
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_soon()) as bg_task:
+                bg_task._step()
+                raise ZeroDivisionError
+            pytest.fail()
+        assert [ZeroDivisionError, ] * 2 == [type(exc) for exc in excinfo.value.exceptions]
+
+    fg_task = ag.start(async_fn())
+    assert fg_task.finished
+
+
+def test_bg_fails_then_fg_fails_2(any_cm):
+    # 裏が停止 -> 表が停止 -> 発火 -> 裏で例外 -> 表を中断 -> 表で例外
+    import asyncgui as ag
+
+    async def fail_soon():
+        await e.wait()
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_soon()):
+                try:
+                    await ag.sleep_forever()
+                finally:
+                    raise ZeroDivisionError
+            pytest.fail()
+        assert [ZeroDivisionError, ] * 2 == [type(exc) for exc in excinfo.value.exceptions]
+
+    e = ag.Event()
+    fg_task = ag.start(async_fn())
+    assert not fg_task.finished
+    e.set()
+    assert fg_task.finished
+
+
+def test_bg_fails_then_fg_fails_3(any_cm):
+    # 裏で例外 -> 表は保護下 -> 根で表を再開 -> 表で例外
+    import asyncgui as ag
+
+    async def fail_imm():
+        raise ZeroDivisionError
+
+    async def async_fn():
+        with pytest.raises(ag.ExceptionGroup) as excinfo:
+            async with any_cm(fail_imm()):
+                async with ag.disable_cancellation():
+                    await ag.sleep_forever()
+                    raise ZeroDivisionError
+            pytest.fail()
+        assert [ZeroDivisionError, ] * 2 == [type(exc) for exc in excinfo.value.exceptions]
+
+    fg_task = ag.start(async_fn())
+    assert not fg_task.finished
+    fg_task._step()
+    assert fg_task.finished
+
+
+def test_both_fail_on_cancel(any_cm):
+    # 裏が停止 -> 表が停止 -> 根で中断 -> 両方で例外
+    import asyncgui as ag
+
+    async def fail_eventually():
+        try:
+            await ag.sleep_forever()
+        finally:
+            raise ZeroDivisionError
+
+    async def async_fn():
+        async with any_cm(fail_eventually()):
+            try:
+                await ag.sleep_forever()
+            finally:
+                raise ZeroDivisionError
+        pytest.fail()
+
+    fg_task = ag.start(async_fn())
+    assert not fg_task.cancelled
+    with pytest.raises(ag.ExceptionGroup) as excinfo:
+        fg_task.cancel()
+    assert [ZeroDivisionError, ] * 2 == [type(exc) for exc in excinfo.value.exceptions]
+    assert fg_task.cancelled
+
+
+def test_bg_fails_on_cancel(any_cm):
+    # 裏が停止 -> 表が停止 -> 根で中断 -> 裏で例外
+    import asyncgui as ag
+
+    async def fail_eventually():
+        try:
+            await ag.sleep_forever()
+        finally:
+            raise ZeroDivisionError
+
+    async def async_fn():
+        async with any_cm(fail_eventually()):
+            await ag.sleep_forever()
+        pytest.fail()
+
+    fg_task = ag.start(async_fn())
+    assert not fg_task.cancelled
+    with pytest.raises(ag.ExceptionGroup) as excinfo:
+        fg_task.cancel()
+    assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+    assert fg_task.cancelled
+
+
+def test_fg_fails_on_cancel(any_cm):
+    # 裏が停止 -> 表が停止 -> 根で中断 -> 表で例外
+    import asyncgui as ag
+
+    async def async_fn():
+        async with any_cm(ag.sleep_forever()):
+            try:
+                await ag.sleep_forever()
+            finally:
+                raise ZeroDivisionError
+        pytest.fail()
+
+    fg_task = ag.start(async_fn())
+    assert not fg_task.cancelled
+    with pytest.raises(ag.ExceptionGroup) as excinfo:
+        fg_task.cancel()
+    assert [ZeroDivisionError, ] == [type(exc) for exc in excinfo.value.exceptions]
+    assert fg_task.cancelled
+
+
+def test_disable_cancellation_1(fg_primary_cm):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_func(ctx):
+        ctx['bg_task'] = await ag.current_task()
+        await ag.sleep_forever()
+        ctx['fg_task'].cancel()
+        await ag.sleep_forever()
+
+    async def async_fn(ctx):
+        ctx['fg_task'] = await ag.current_task()
+        async with fg_primary_cm(bg_func(ctx)) as bg_task:
+            async with ag.disable_cancellation():
+                await ag.sleep_forever()
+            assert bg_task.state is TS.STARTED
+        pytest.fail()
+
+    ctx = {}
+    fg_task = ag.start(async_fn(ctx))
+    bg_task = ctx['bg_task']
+    assert fg_task.state is TS.STARTED
+    assert bg_task.state is TS.STARTED
+    bg_task._step()
+    assert fg_task.state is TS.STARTED
+    assert bg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.CANCELLED
+    assert bg_task.state is TS.CANCELLED
+
+
+def test_disable_cancellation_2(fg_primary_cm):
+    # 1とは違い中断保護を fg_primary_cm の外側で行う
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_func(ctx):
+        ctx['bg_task'] = await ag.current_task()
+        await ag.sleep_forever()
+        ctx['fg_task'].cancel()
+        await ag.sleep_forever()
+
+    async def async_fn(ctx):
+        ctx['fg_task'] = await ag.current_task()
+        async with ag.disable_cancellation():
+            async with fg_primary_cm(bg_func(ctx)) as bg_task:
+                await ag.sleep_forever()
+            assert bg_task.state is TS.CANCELLED
+        assert bg_task.state is TS.CANCELLED
+
+    ctx = {}
+    fg_task = ag.start(async_fn(ctx))
+    bg_task = ctx['bg_task']
+    assert fg_task.state is TS.STARTED
+    assert bg_task.state is TS.STARTED
+    bg_task._step()
+    assert fg_task.state is TS.STARTED
+    assert bg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED
+    assert bg_task.state is TS.CANCELLED
+
+
+def test_disable_cancellation_3(bg_primary_cm):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_func(ctx):
+        ctx['bg_task'] = await ag.current_task()
+        await ag.sleep_forever()
+        ctx['scope'].cancel()
+        await ag.sleep_forever()
+
+    async def async_fn(ctx):
+        ctx['fg_task'] = await ag.current_task()
+        async with bg_primary_cm(bg_func(ctx)) as bg_task:
+            async with ag.open_cancel_scope() as scope:
+                ctx['scope'] = scope
+                async with ag.disable_cancellation():
+                    assert bg_task.state is TS.STARTED
+                    bg_task._step()
+                    assert bg_task.state is TS.STARTED
+                    await ag.sleep_forever()
+                await ag.sleep_forever()
+                pytest.fail()
+            await ag.sleep_forever()
+            pytest.fail()
+
+    ctx = {}
+    fg_task = ag.start(async_fn(ctx))
+    bg_task = ctx['bg_task']
+    assert fg_task.state is TS.STARTED
+    assert bg_task.state is TS.STARTED
+    fg_task._step()
+    assert fg_task.state is TS.STARTED
+    assert bg_task.state is TS.STARTED
+    bg_task._step()
+    assert fg_task.state is TS.FINISHED
+    assert bg_task.state is TS.FINISHED
+
+
+def test_disable_cancellation_4(bg_primary_cm):
+    # 3とは違い中断保護を bg_primary_cm の外側で行う
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def bg_func(ctx):
+        ctx['bg_task'] = await ag.current_task()
+        await ag.sleep_forever()
+        ctx['fg_task'].cancel()
+
+    async def async_fn(ctx):
+        ctx['fg_task'] = await ag.current_task()
+        async with ag.disable_cancellation():
+            async with bg_primary_cm(bg_func(ctx)) as bg_task:
+                assert bg_task.state is TS.STARTED
+                bg_task._step()
+                assert bg_task.state is TS.FINISHED
+                await ag.sleep_forever()
+            assert bg_task.state is TS.FINISHED
+
+    ctx = {}
+    fg_task = ag.start(async_fn(ctx))
+    bg_task = ctx['bg_task']
+    assert fg_task.state is TS.STARTED
+    assert bg_task.state is TS.FINISHED
+    fg_task._step()
+    assert fg_task.state is TS.FINISHED
+    assert bg_task.state is TS.FINISHED

--- a/tests/utils/wait_any/test_simple_situation.py
+++ b/tests/utils/wait_any/test_simple_situation.py
@@ -37,7 +37,7 @@ def test_no_child():
 
     async def main():
         tasks = await ag.wait_any()
-        assert tasks == []
+        assert tasks == tuple()
 
     main_task = ag.start(main())
     assert main_task.finished


### PR DESCRIPTION
新たな内部用部品である `TaskCounter` を用いて各種APIの実装を簡略する。加えて以下の破壊的変更を行う。

- `run_and_cancelling()` を `run_as_secondary()` に名称変更。
- `wait_all()` と `wait_any()` はlistではなくtupleを返す。
